### PR TITLE
Do not penalize app boot if command deck is disabled.

### DIFF
--- a/lib/command_deck/engine.rb
+++ b/lib/command_deck/engine.rb
@@ -9,6 +9,8 @@ module CommandDeck
     isolate_namespace CommandDeck
 
     initializer "command_deck.add_autoload_paths", before: :set_autoload_paths do |app|
+      next unless ENV.fetch("COMMAND_DECK_ENABLED", "false") == "true"
+
       Engine.discover_panel_paths.each do |path|
         app.config.autoload_paths << path.to_s unless app.config.autoload_paths.include?(path.to_s)
       end


### PR DESCRIPTION
Our large application currently takes too long to boot in development mode. While investigating this, I discovered that the add_autoload_paths hook in the command_gem gem still executes even when COMMAND_DECK_ENABLED is set to false. To resolve this, I added a guard clause to skip loading the panel paths when the deck is disabled.

Running bumbler `COMMAND_DECK_ENABLED=false bundle exec bumbler --initializers`, shows the following.

Before:
```ssh
Slow requires:
    219.65  :set_clear_dependencies_hook
    244.75  :setup_main_autoloader
    413.02  command_deck.add_autoload_paths # almost half second!
    638.29  :run_prepare_callbacks
    673.63  :finisher_hook
   3590.77  :set_routes_reloader_hook
```

After:
```ssh
Slow requires:
    223.91  :set_clear_dependencies_hook
    227.29  :setup_main_autoloader
    663.30  :run_prepare_callbacks  # the hook is not running anymore
    692.83  :finisher_hook
   3485.41  :set_routes_reloader_hook
```

Would be sweet if we could speed up `Engine.discover_panel_paths` too, but for me this is enough.